### PR TITLE
Add support for custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ is also handled transparently.
 This tool uses rules from the Gitleaks project (https://gitleaks.io) to detect secrets.
 
 Flags:
+  -c, --custom stringArray     additional custom rule to apply. Secrets that match the
+                               given regular expression (using RE2 syntax) will also be
+                               reported. Can be specified multiple times.
   -e, --enclosed               only report secrets that are enclosed within their context
   -f, --filter string          filter for the target URL of each WARC record. Only WARC
                                records that match the given regular expression (using RE2
@@ -115,6 +118,9 @@ Flags:
                                             biggest culprits for false positives.
                                secret:      Only rules are applied that are most likely
                                             to result in an actual leak of a secret.
+                               none:        No rules at all are applied. This can be used
+                                            in combination with custom rules via the
+                                            --custom/-c switch.
                                No other values are allowed. (default secret)
   -q, --quiet                  suppress success message(s)
   -r, --retry retry-strategy   retry strategy to use. This could be one of the following:

--- a/internal/cli/rules-preset.go
+++ b/internal/cli/rules-preset.go
@@ -23,6 +23,8 @@ func (rp RulesPreset) String() string {
 		return "most"
 	case len(preset.Secret):
 		return "secret"
+	case len(preset.None):
+		return "none"
 	}
 
 	return ""
@@ -40,10 +42,13 @@ func (rp *RulesPreset) Set(s string) error {
 	case "secret":
 		rp.Val = preset.Secret
 		return nil
+	case "none":
+		rp.Val = preset.None
+		return nil
 	}
 
 	// Invalid
-	return errors.New(`must be one of "all", "most", or "secret"`)
+	return errors.New(`must be one of "all", "most", "secret", or "none"`)
 }
 
 // Type returns the name of the rules preset type.

--- a/main.go
+++ b/main.go
@@ -88,6 +88,9 @@ most:        Most of the rules are applied, skipping the
              biggest culprits for false positives.
 secret:      Only rules are applied that are most likely
              to result in an actual leak of a secret.
+none:        No rules at all are applied. This can be
+             used in combination with custom rules via
+             the --custom/-c switch.
 No other values are allowed.`)
 
 	cmd.Flags().VarP(&configRetry, "retry", "r", `retry strategy to use. This could be one of the following:

--- a/pkg/detect/preset/none.go
+++ b/pkg/detect/preset/none.go
@@ -1,0 +1,8 @@
+package preset
+
+import (
+	"github.com/crissyfield/troll-a/pkg/detect"
+)
+
+// None is an emply list of secrets, access and refresh token detection rules.
+var None = []detect.GitleaksRuleFunction{}

--- a/pkg/detect/rule.go
+++ b/pkg/detect/rule.go
@@ -1,6 +1,8 @@
 package detect
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/zricethezav/gitleaks/v8/config"
@@ -28,5 +30,14 @@ func NewRuleFromGitleaksRule(r *config.Rule) *Rule {
 		SecretGroup: r.SecretGroup,
 		Regex:       CloneRegexp(r.Regex),
 		Allowlists:  r.Allowlists,
+	}
+}
+
+// NewRuleFromRegExp creates a Rule object from a regular expression.
+func NewRuleFromRegExp(re *regexp.Regexp, idx int) *Rule {
+	return &Rule{
+		RuleID:      fmt.Sprintf("custom-rule-%d", idx),
+		Description: fmt.Sprintf("Custom rule #%d (as specified via command line)", idx),
+		Regex:       CloneRegexp(re),
 	}
 }


### PR DESCRIPTION
As requested in #1 this introduces a new command line switch (`--custom`/`-c`) to add custom rules as regular expressions to the set of rules to check for. Additionally, this adds a new preset (`none`) to start of with an empty set of rules.